### PR TITLE
Always fetch commit SHA

### DIFF
--- a/findRefOnGithub.js
+++ b/findRefOnGithub.js
@@ -9,27 +9,50 @@ module.exports = function(action) {
     const repo = action.repo;
     const pinned = action.pinnedVersion;
 
-    let sha = null;
-
-    // In order: SHA, Tag, Branch
-    const possibleRefs = [pinned, `tags/${pinned}`, `heads/${pinned}`];
+    // In order: Tag, Branch
+    const possibleRefs = [`tags/${pinned}`, `heads/${pinned}`];
     for (let ref of possibleRefs) {
       try {
-        sha = (
+        const object = (
           await github.git.getRef({
             owner,
             repo,
             ref
           })
-        ).data.object.sha;
+        ).data.object;
 
-        if (sha) {
-          return resolve(sha);
+        // If it's a tag, fetch the commit hash instead
+        if (object.type === "tag") {
+          // Fetch the commit hash instead
+          const tag = await github.git.getTag({
+            owner,
+            repo,
+            tag_sha: object.sha
+          });
+          return resolve(tag.data.object.sha);
+        }
+
+        // If it's already a commit, return that
+        if (object.type === "commit") {
+          return resolve(object.sha);
         }
       } catch (e) {
         // We can ignore failures as we validate later
         //console.log(e);
       }
+    }
+
+    // If we get this far, have we been provided with a specific commit SHA?
+    try {
+      const commit = await github.repos.getCommit({
+        owner,
+        repo,
+        ref: pinned
+      });
+      return resolve(commit.data.sha);
+    } catch (e) {
+      // If it's not a commit, it doesn't matter
+      //console.log(e);
     }
 
     return reject(

--- a/findRefOnGithub.test.js
+++ b/findRefOnGithub.test.js
@@ -10,14 +10,32 @@ const action = {
   currentVersion: "master"
 };
 
-test("looks up a specific ref", async () => {
+afterEach(() => {
+  if (!nock.isDone()) {
+    throw new Error(
+      `Not all nock interceptors were used: ${JSON.stringify(
+        nock.pendingMocks()
+      )}`
+    );
+  }
+  nock.cleanAll();
+});
+
+test("looks up a specific hash", async () => {
   const testAction = {
     ...action,
     pinnedVersion: "73549280c1c566830040d9a01fe9050dae6a3036"
   };
-  mockRefLookupSuccess(
+  mockRefLookupFailure(
     testAction,
-    "73549280c1c566830040d9a01fe9050dae6a3036",
+    "tags/73549280c1c566830040d9a01fe9050dae6a3036"
+  );
+  mockRefLookupFailure(
+    testAction,
+    "heads/73549280c1c566830040d9a01fe9050dae6a3036"
+  );
+  mockCommitLookupSuccess(
+    testAction,
     "73549280c1c566830040d9a01fe9050dae6a3036"
   );
   const actual = await findRef(testAction);
@@ -26,20 +44,23 @@ test("looks up a specific ref", async () => {
 
 test("looks up a tag", async () => {
   const testAction = { ...action, pinnedVersion: "v1" };
-  mockRefLookupFailure(testAction, "master");
-  mockRefLookupSuccess(
+  mockTagRefLookupSuccess(
     testAction,
     "tags/v1",
     "73549280c1c566830040d9a01fe9050dae6a3036"
   );
+  mockTagLookupSuccess(
+    testAction,
+    "73549280c1c566830040d9a01fe9050dae6a3036",
+    "62ffef0ba7de4e1410b3c503be810ec23842e34a"
+  );
   const actual = await findRef(testAction);
-  expect(actual).toEqual("73549280c1c566830040d9a01fe9050dae6a3036");
+  expect(actual).toEqual("62ffef0ba7de4e1410b3c503be810ec23842e34a");
 });
 
 test("looks up a branch", async () => {
-  mockRefLookupFailure(action, "master");
   mockRefLookupFailure(action, "tags/master");
-  mockRefLookupSuccess(
+  mockBranchRefLookupSuccess(
     action,
     "heads/master",
     "73549280c1c566830040d9a01fe9050dae6a3036"
@@ -49,9 +70,9 @@ test("looks up a branch", async () => {
 });
 
 test("fails to find ref", () => {
-  mockRefLookupFailure(action, "master");
   mockRefLookupFailure(action, "tags/master");
   mockRefLookupFailure(action, "heads/master");
+  mockCommitLookupFailure(action, "master");
   return expect(findRef(action)).rejects.toEqual(
     `Unable to find SHA for nexmo/github-actions@master\nPrivate repos require you to set process.env.GH_ADMIN_TOKEN to fetch the latest SHA`
   );
@@ -63,18 +84,55 @@ function mockRefLookupFailure(action, path) {
     .reply(404);
 }
 
-function mockRefLookupSuccess(action, path, sha) {
+function mockBranchRefLookupSuccess(action, path, sha) {
   const data = {
     ref: `refs/${path}`,
-    node_id: "MDM6UmVmMTkxMzQ3NTIzOm1hc3Rlcg==",
-    url: `https://api.github.com/repos/${action.owner}/${action.repo}/git/ref/${path}`,
     object: {
       sha: sha,
-      type: "commit",
-      url: `https://api.github.com/repos/${action.owner}/${action.repo}/git/commits/${sha}`
+      type: "commit"
     }
   };
   nock("https://api.github.com")
     .get(`/repos/${action.owner}/${action.repo}/git/ref/${path}`)
     .reply(200, data);
+}
+
+function mockTagRefLookupSuccess(action, path, sha) {
+  const data = {
+    ref: `refs/${path}`,
+    object: {
+      sha: sha,
+      type: "tag"
+    }
+  };
+  nock("https://api.github.com")
+    .get(`/repos/${action.owner}/${action.repo}/git/ref/${path}`)
+    .reply(200, data);
+}
+
+function mockTagLookupSuccess(action, tagSha, commitSha) {
+  const data = {
+    object: {
+      sha: commitSha,
+      type: "commit"
+    }
+  };
+
+  nock("https://api.github.com")
+    .get(`/repos/${action.owner}/${action.repo}/git/tags/${tagSha}`)
+    .reply(200, data);
+}
+
+function mockCommitLookupSuccess(action, commitSha) {
+  nock("https://api.github.com")
+    .get(`/repos/${action.owner}/${action.repo}/commits/${commitSha}`)
+    .reply(200, {
+      sha: commitSha
+    });
+}
+
+function mockCommitLookupFailure(action, commitSha) {
+  nock("https://api.github.com")
+    .get(`/repos/${action.owner}/${action.repo}/commits/${commitSha}`)
+    .reply(404);
 }


### PR DESCRIPTION
This fixes an issue where a tag SHA used to be accepted by the GH Actions runner but is no longer working.

The documentation has always specified _commit_ hash, and this commit adds support for looking up a commit SHA when provided with a tag ref

Resolves #21 