### PR TITLE
Add composite action support

### DIFF
--- a/extractActions.js
+++ b/extractActions.js
@@ -1,4 +1,30 @@
 module.exports = function (input, allowEmpty) {
+  // Check if it's a composite action
+  let runs = input.contents.items.filter((n) => n.key == "runs");
+  if (runs.length) {
+    return extractFromComposite(input, allowEmpty);
+  }
+
+  return extractFromWorkflow(input, allowEmpty);
+};
+
+function extractFromComposite(input, allowEmpty) {
+  let runs = input.contents.items.filter((n) => n.key == "runs");
+  let steps = runs[0].value.items.filter((n) => n.key == "steps");
+
+  if (!steps.length) {
+    throw new Error("No runs.steps found");
+  }
+
+  const actions = new Set();
+  steps = steps[0].value.items;
+  for (let step of steps) {
+    handleStep(actions, step);
+  }
+  return Array.from(actions);
+}
+
+function extractFromWorkflow(input, allowEmpty) {
   let actions = new Set();
 
   let jobs = input.contents.items.filter((n) => n.key == "jobs");
@@ -21,39 +47,42 @@ module.exports = function (input, allowEmpty) {
       throw new Error("No job.steps found");
     }
 
-    let actionsDetected = false;
     for (let step of steps) {
-      const uses = step.items.filter((n) => n.key == "uses");
-      if (uses.length) {
-        actionsDetected = true;
-      }
-      for (let use of uses) {
-        const line = use.value.value.toString();
-
-        if (line.substr(0, 9) == "docker://") {
-          continue;
-        }
-        if (line.substr(0, 2) == "./") {
-          continue;
-        }
-
-        const details = parseAction(line);
-        let original = (use.value.comment || "").replace(" pin@", "");
-        if (!original) {
-          original = details.currentVersion;
-        }
-
-        actions.add({ ...details, pinnedVersion: original });
-      }
-    }
-
-    if (!actionsDetected && !allowEmpty) {
-      throw new Error("No Actions detected");
+      handleStep(actions, step);
     }
   }
 
+  if (actions.size === 0 && !allowEmpty) {
+    throw new Error("No Actions detected");
+  }
+
   return Array.from(actions);
-};
+}
+
+function handleStep(actions, step) {
+  const uses = step.items.filter((n) => n.key == "uses");
+
+  for (let use of uses) {
+    const line = use.value.value.toString();
+
+    if (line.substr(0, 9) == "docker://") {
+      continue;
+    }
+    if (line.substr(0, 2) == "./") {
+      continue;
+    }
+
+    const details = parseAction(line);
+    let original = (use.value.comment || "").replace(" pin@", "");
+    if (!original) {
+      original = details.currentVersion;
+    }
+
+    actions.add({ ...details, pinnedVersion: original });
+  }
+
+  return actions;
+}
 
 function parseAction(str) {
   const [name, version] = str.split("@");

--- a/extractActions.test.js
+++ b/extractActions.test.js
@@ -335,6 +335,33 @@ test("does not throw when mixing run and uses", () => {
   ]);
 });
 
+test("extracts from composite actions", () => {
+  const input = convertToAst({
+    name: "Sample Composite",
+    runs: {
+      using: "composite",
+      steps: [
+        {
+          name: "With An Action",
+          uses: "mheap/test-action@master",
+        },
+      ],
+    },
+  });
+
+  const actual = extractActions(input);
+
+  expect(actual).toEqual([
+    {
+      owner: "mheap",
+      repo: "test-action",
+      path: "",
+      currentVersion: "master",
+      pinnedVersion: "master",
+    },
+  ]);
+});
+
 function convertToAst(input) {
   return YAML.parseDocument(YAML.stringify(input));
 }

--- a/replaceActions.js
+++ b/replaceActions.js
@@ -1,4 +1,40 @@
 module.exports = function (input, action) {
+  let runs = input.contents.items.filter((n) => n.key == "runs");
+  if (runs.length) {
+    return replaceInComposite(input, action);
+  }
+
+  return replaceInWorkflow(input, action);
+};
+
+function replaceInComposite(input, action) {
+  let actionString = `${action.owner}/${action.repo}`;
+  if (action.path) {
+    actionString += `/${action.path}`;
+  }
+
+  const replacement = `${actionString}@${action.newVersion}`;
+
+  actionString += `@${action.currentVersion}`;
+
+  const runs = input.contents.items.filter((n) => n.key == "runs")[0].value
+    .items;
+  const steps = runs.filter((n) => n.key == "steps")[0].value.items;
+
+  for (let step of steps) {
+    const uses = step.items.filter((n) => n.key == "uses");
+    for (let use of uses) {
+      if (use.value.value == actionString) {
+        use.value.value = replacement;
+        use.value.comment = ` pin@${action.pinnedVersion}`;
+      }
+    }
+  }
+
+  return input;
+}
+
+function replaceInWorkflow(input, action) {
   let actionString = `${action.owner}/${action.repo}`;
   if (action.path) {
     actionString += `/${action.path}`;
@@ -26,4 +62,4 @@ module.exports = function (input, action) {
   }
 
   return input;
-};
+}

--- a/replaceActions.test.js
+++ b/replaceActions.test.js
@@ -10,7 +10,7 @@ const action = {
   newVersion: "sha-here",
 };
 
-test("replaces a single action with a sha", () => {
+test("replaces a single action with a sha (workflow)", () => {
   const input = convertToAst({
     name: "PR",
     on: ["pull_request"],
@@ -24,6 +24,25 @@ test("replaces a single action with a sha", () => {
           },
         ],
       },
+    },
+  });
+
+  const actual = replaceActions(input, { ...action }).toString();
+
+  expect(actual).toContain("uses: mheap/test-action@sha-here # pin@master");
+});
+
+test("replaces a single action with a sha (composite)", () => {
+  const input = convertToAst({
+    name: "Sample Composite",
+    runs: {
+      using: "composite",
+      steps: [
+        {
+          name: "With An Action",
+          uses: "mheap/test-action@master",
+        },
+      ],
     },
   });
 


### PR DESCRIPTION
Add support for pinning actions in composite `action.yml` files.

The code could use some cleanup, but the tests pass and it resolves #44 so let's :shipit: and refactor