### PR TITLE
feature: new "literal" flag to do string replacement within literal i…

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,8 @@ module.exports = async function (
   allowed,
   ignoreShas,
   allowEmpty,
-  debug
+  debug,
+  literal
 ) {
   allowed = allowed || [];
   ignoreShas = ignoreShas || false;
@@ -38,7 +39,7 @@ module.exports = async function (
     actions[i].newVersion = newVersion;
 
     // Rewrite each action, replacing the uses block with a specific sha
-    workflow = replaceActions(workflow, actions[i]);
+    workflow = replaceActions(workflow, actions[i],literal,input);
   }
 
   return {


### PR DESCRIPTION
- feature: new "literal" flag to do string replacement within literal input rather than in parsed yaml, in order to avoid conflicts with yaml-lint

- feature: new "in-place" flag to write to stdout instead of the input file, in order to make destructive edits not the default
