### PR TITLE
Create CLI parameter to write output to stdout

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -25,6 +25,10 @@ const packageDetails = require(path.join(__dirname, "package.json"));
         "-e, --allow-empty",
         "allow workflows that do not contain any actions"
       )
+      .option(
+        "-s, --safe",
+        "write changes to stdout"
+      )
       .parse(process.argv);
 
     const filename = program.args[0];
@@ -37,13 +41,16 @@ const packageDetails = require(path.join(__dirname, "package.json"));
     let allowed = program.opts().allow;
     allowed = (allowed || "").split(",").filter((r) => r);
     let ignoreShas = program.opts().ignoreShas;
+    let allowEmpty = program.opts().allowEmpty;
+    let safeMode = program.opts().safe ? true : false;
 
     const input = fs.readFileSync(filename).toString();
-
-    let allowEmpty = program.opts().allowEmpty;
     const output = await run(input, allowed, ignoreShas, allowEmpty, debug);
 
-    fs.writeFileSync(filename, output.workflow);
+    if (safeMode)
+      console.log(output.workflow);
+    else
+      fs.writeFileSync(filename, output.workflow);
 
     // Once run on a schedule, have it return a list of changes, along with SHA links
     // and generate a PR to update the actions to the latest version. This allows them a

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pin-github-action",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Pin your GitHub Actions to specific versions automatically!",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Create --s, --safe CLI parameter to write output to stdout instead of back to input file. Useful for debugging or redirecting to a file or pipe.
    
Note 1.6.1 version, same as my other PR.

Signed-off-by: Lucas Gonze <lucas@gonze.com>