### PR TITLE
Allow pin@{ref} comment to be customised

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,16 @@ Examples:
 - Partial match: `actions/*`
 - Negated match: `!actions/*` (will only pin `actions/*` actions)
 
+## Customising the pin@{ref} comment
+
+You can specify a comment containing the `{ref}` placeholder to customise the comment added.
+
+To add [support for renovate](https://github.com/mheap/pin-github-action/issues/140), run with the following options (note the leading space):
+
+```bash
+pin-github-action -c " {ref}" /path/to/workflow.yaml
+```
+
 ## How it works
 
 - Load the workflow file provided

--- a/bin.js
+++ b/bin.js
@@ -37,6 +37,11 @@ const packageDetails = require(path.join(__dirname, "package.json"));
         "set string representation for null values",
         "null"
       )
+      .option(
+        "-c, --comment <string>",
+        "comment to add inline when pinning an action",
+        " pin@{ref}"
+      )
       .parse(process.argv);
 
     if (program.args.length == 0) {
@@ -49,6 +54,7 @@ const packageDetails = require(path.join(__dirname, "package.json"));
     let allowEmpty = program.opts().allowEmpty;
     let yamlLineWidth = program.opts().yamlLineWidth;
     let yamlNullStr = program.opts().yamlNullStr;
+    let comment = program.opts().comment;
 
     for (const filename of program.args) {
       if (!fs.existsSync(filename)) {
@@ -65,7 +71,8 @@ const packageDetails = require(path.join(__dirname, "package.json"));
         allowEmpty,
         debug,
         yamlLineWidth,
-        yamlNullStr
+        yamlNullStr,
+        comment
       );
       fs.writeFileSync(filename, output.workflow);
     }

--- a/index.js
+++ b/index.js
@@ -13,7 +13,8 @@ module.exports = async function (
   allowEmpty,
   debug,
   yamlLineWidth,
-  yamlNullStr
+  yamlNullStr,
+  comment
 ) {
   allowed = allowed || [];
   ignoreShas = ignoreShas || false;
@@ -40,7 +41,7 @@ module.exports = async function (
     actions[i].newVersion = newVersion;
 
     // Rewrite each action, replacing the uses block with a specific sha
-    workflow = replaceActions(workflow, actions[i]);
+    workflow = replaceActions(workflow, actions[i], comment);
   }
 
   stringOpts = {

--- a/replaceActions.test.js
+++ b/replaceActions.test.js
@@ -32,6 +32,28 @@ test("replaces a single action with a sha (workflow)", () => {
   expect(actual).toContain("uses: mheap/test-action@sha-here # pin@master");
 });
 
+test("supports a custom comment format (workflow)", () => {
+  const input = convertToAst({
+    name: "PR",
+    on: ["pull_request"],
+    jobs: {
+      "test-job": {
+        "runs-on": "ubuntu-latest",
+        steps: [
+          {
+            name: "test action step",
+            uses: "mheap/test-action@master",
+          },
+        ],
+      },
+    },
+  });
+
+  const actual = replaceActions(input, { ...action }, " {ref}").toString();
+
+  expect(actual).toContain("uses: mheap/test-action@sha-here # master");
+});
+
 test("replaces a single action with a sha (composite)", () => {
   const input = convertToAst({
     name: "Sample Composite",
@@ -51,6 +73,25 @@ test("replaces a single action with a sha (composite)", () => {
   expect(actual).toContain("uses: mheap/test-action@sha-here # pin@master");
 });
 
+test("supports a custom comment format (composite)", () => {
+  const input = convertToAst({
+    name: "Sample Composite",
+    runs: {
+      using: "composite",
+      steps: [
+        {
+          name: "With An Action",
+          uses: "mheap/test-action@master",
+        },
+      ],
+    },
+  });
+
+  const actual = replaceActions(input, { ...action }, " {ref}").toString();
+
+  expect(actual).toContain("uses: mheap/test-action@sha-here # master");
+});
+
 test("replaces a single action with a sha (reusable)", () => {
   const input = convertToAst({
     name: "Sample Reusable",
@@ -64,6 +105,21 @@ test("replaces a single action with a sha (reusable)", () => {
   const actual = replaceActions(input, { ...action }).toString();
 
   expect(actual).toContain("uses: mheap/test-action@sha-here # pin@master");
+});
+
+test("supports a custom comment format (reusable)", () => {
+  const input = convertToAst({
+    name: "Sample Reusable",
+    jobs: {
+      test: {
+        uses: "mheap/test-action@master",
+      },
+    },
+  });
+
+  const actual = replaceActions(input, { ...action }, " {ref}").toString();
+
+  expect(actual).toContain("uses: mheap/test-action@sha-here # master");
 });
 
 test("replaces an existing sha with a different sha, not changing the pinned branch", () => {


### PR DESCRIPTION
Adds the `-c` flag to customise the comment that is added to pinned workflows

Resolves #140 