### PR TITLE
Fix ignoreShas error when workflow contains SHAs

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -63,7 +63,7 @@ const packageDetails = JSON.parse(
         debug,
         comment
       );
-      fs.writeFileSync(filename, output.workflow);
+      fs.writeFileSync(filename, output.workflow.toString());
     }
 
     // Once run on a schedule, have it return a list of changes, along with SHA links


### PR DESCRIPTION
If `ignoreShas` is provided and all actions contain a SHA, the YAML AST is passed to `fs.writeFileSync`. By explicitly adding `.toString()` we can ensure that string data is passed no matter which object type is returned from `index.js`

Resolves #175 