### PR TITLE
Pin all actions commits

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -63,7 +63,7 @@ const packageDetails = JSON.parse(
         debug,
         comment
       );
-      fs.writeFileSync(filename, output.workflow.toString());
+      fs.writeFileSync(filename, output.input);
     }
 
     // Once run on a schedule, have it return a list of changes, along with SHA links

--- a/index.js
+++ b/index.js
@@ -38,11 +38,11 @@ export default async function (
     actions[i].newVersion = newVersion;
 
     // Rewrite each action, replacing the uses block with a specific sha
-    workflow = replaceActions(input, actions[i], comment);
+    input = replaceActions(input, actions[i], comment);
   }
 
   return {
-    workflow,
+    input,
     actions,
   };
 }


### PR DESCRIPTION
In previous code only last result of replacement was returned in final return, meaning only last action was pinned. 

This solves https://github.com/mheap/pin-github-action/issues/180