### PR TITLE
[feature] Don't fail fast on list of actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ Use on all YAML|YML files in directory:
 pin-github-action /path/to/.github/workflows/
 ```
 
+If you run the tool on a directory and want to continue processing when a single file fails, pass the `--continue-on-error` parameter:
+
+```bash
+pin-github-action --continue-on-error /path/to/.github/workflows/
+```
+
 If you use private actions (or are hitting rate limits), you'll need to provide
 a GitHub access token:
 

--- a/bin.js
+++ b/bin.js
@@ -40,6 +40,10 @@ const packageDetails = JSON.parse(
         " {ref}",
       )
       .option(
+        "--continue-on-error",
+        "continue processing files even if an error occurs",
+      )
+      .option(
         "--enforce <filename>",
         "create a workflow at <filename> that ensures all actions are pinned",
       )
@@ -54,6 +58,7 @@ const packageDetails = JSON.parse(
     let ignoreShas = program.opts().ignoreShas;
     let allowEmpty = program.opts().allowEmpty;
     let comment = program.opts().comment;
+    const continueOnError = program.opts().continueOnError;
 
     // Check if we're adding the security file
     if (program.opts().enforce) {
@@ -74,8 +79,6 @@ const packageDetails = JSON.parse(
       throw "Didn't find Y(A)ML files in provided paths: " + program.args;
     }
 
-    const shouldFailFast = filesToProcess.length === 1;
-
     for (const filename of filesToProcess) {
       mainDebug("Processing " + filename);
       const input = fs.readFileSync(filename).toString();
@@ -91,7 +94,7 @@ const packageDetails = JSON.parse(
         );
       }
       catch (e) {
-        if (shouldFailFast) {
+        if (!continueOnError) {
           throw e;
         }
         else {


### PR DESCRIPTION
When running this on a big list of files, it's kind of annoying if it fails when it encounters a single action it can't parse properly.