### PR TITLE
Improve error message when input is invalid

### DIFF
--- a/extractActions.js
+++ b/extractActions.js
@@ -41,7 +41,13 @@ function extractFromWorkflow(input, allowEmpty, comment) {
   }
 
   for (let job of jobs) {
-    // Check for
+    if (!job.value) {
+      throw new Error(
+        "Error parsing workflow. Is this a valid GitHub Actions workflow?\n\n" +
+          input.toString(),
+      );
+    }
+
     let steps = job.value.items.filter(
       (n) => n.key == "steps" || n.key == "uses",
     );


### PR DESCRIPTION
When `job` is a list and not a `map`, `pin-github-action` returned `Cannot read properties of undefined (reading 'items')`

This PR improves the error message

Resolves #191