### PR TITLE
Chore: Add information about when api limits will reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,3 +178,19 @@ pin-github-action -c " pin@{ref}" /path/to/workflow.yaml
 - Look up the current SHA for each repo on GitHub and update the action to use the specific hash
   - If needed, add a comment with the target pinned version
 - Write the workflow file with the new pinned version and original target version as a comment
+
+## Contributing
+
+1. **Run tests**: Ensure all tests pass before submitting your changes.
+
+```bash
+npm install
+npm test
+```
+
+2. **Build and test locally using Docker**: You can build a container and test the application locally.
+
+```bash
+docker build -t pin-github-action .
+docker run --rm -v $(pwd):/workflows -e GITHUB_TOKEN=<your-token-here> pin-github-action /path/to/.github/workflows/your-name.yml
+```

--- a/findRefOnGithub.js
+++ b/findRefOnGithub.js
@@ -101,8 +101,14 @@ function handleCommonErrors(e, name) {
   }
 
   if (e.message.includes("API rate limit exceeded")) {
-    debug(`[${name}] ERROR: Rate Limiting error`);
-    return e.message;
+    const resetTime = e.response?.headers["x-ratelimit-reset"];
+    const resetDate = resetTime
+      ? new Date(resetTime * 1000).toLocaleString()
+      : "unknown";
+    debug(
+      `[${name}] ERROR: Rate Limiting error. Limit resets at: ${resetDate}`,
+    );
+    return `${e.message} Limit resets at: ${resetDate}`;
   }
   return "";
 }

--- a/findRefOnGithub.test.js
+++ b/findRefOnGithub.test.js
@@ -89,7 +89,7 @@ test("fails to find ref (rate limiting)", () => {
   mockRefLookupFailure(action, "heads/master");
   mockCommitLookupRateLimit(action, "master");
   return expect(findRef(action)).rejects.toEqual(
-    `Unable to find SHA for nexmo/github-actions@master\nAPI rate limit exceeded for 1.2.3.4. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)`,
+    `Unable to find SHA for nexmo/github-actions@master\nAPI rate limit exceeded for 1.2.3.4. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.) Limit resets at: 4/9/2025, 8:08:44 AM`,
   );
 });
 
@@ -161,5 +161,8 @@ function mockCommitLookupRateLimit(action, commitSha) {
     .reply(
       429,
       "API rate limit exceeded for 1.2.3.4. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)",
+      {
+        "x-ratelimit-reset": "1744211324",
+      },
     );
 }

--- a/findRefOnGithub.test.js
+++ b/findRefOnGithub.test.js
@@ -88,8 +88,9 @@ test("fails to find ref (rate limiting)", () => {
   mockRefLookupFailure(action, "tags/master");
   mockRefLookupFailure(action, "heads/master");
   mockCommitLookupRateLimit(action, "master");
+  const resetDate = new Date(1744211324000).toLocaleString();
   return expect(findRef(action)).rejects.toEqual(
-    `Unable to find SHA for nexmo/github-actions@master\nAPI rate limit exceeded for 1.2.3.4. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.) Limit resets at: 4/9/2025, 8:08:44 AM`,
+    `Unable to find SHA for nexmo/github-actions@master\nAPI rate limit exceeded for 1.2.3.4. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.) Limit resets at: ${resetDate}`,
   );
 });
 


### PR DESCRIPTION
Why do we need this change?
=======================
Rather than forcing folks to go lookup via a separate call to the rate-limits api, grab the information directly from the github response and provide insight to let folks know when they will be able to make requests again.

What effects does this change have?
=======================
* Update tests to support new outputs
* Update to print info about when your api limits will be reset