### PR TITLE
Fix recursive file detection

### DIFF
--- a/collectWorkflowFiles.js
+++ b/collectWorkflowFiles.js
@@ -14,11 +14,12 @@ export default function (programArgs, recursive) {
     if (fs.lstatSync(pathname).isFile()) {
       filesToProcess.push(pathname);
     } else {
-      let globPattern = "*/*.{yaml,yml}";
+      let globPattern = "*.{yaml,yml}";
       if (recursive) {
         globPattern = "**/*.{yaml,yml}";
       }
-      const files = glob.sync(globPattern);
+
+      const files = glob.sync(path.join(`${pathname}`, globPattern));
       filesToProcess = filesToProcess.concat(files);
     }
   }


### PR DESCRIPTION
The path passed to `pin-github-action` needed to be prepended to the glob path when searching for files