### PR TITLE
Wrap the pin actions tool as a github action

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,5 @@ ENV WORKFLOWS_DIR=/workflows
 
 # Set the entry point for the container to run the CLI
 # Replace 'your-cli-command' with the actual command of your CLI app
-ENTRYPOINT ["node", "/src/bin.js"]
+ENTRYPOINT ["/src/entrypoint.sh"]
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,17 @@ npm install -g pin-github-action
 alias pin-github-action='docker run --rm -v $(pwd):/workflows -e GITHUB_TOKEN mheap/pin-github-action'
 ```
 
+## Github action
+
+You can also use this as a GitHub action in your workflow:
+
+```yaml
+  - name: Pin GitHub Actions
+    uses: mheap/pin-github-action@sha1233 # vn.n.n
+    with:
+      token: ${{ secrets.GITHUB_TOKEN }}
+```
+
 ## Usage
 
 Use on single file:

--- a/action.yaml
+++ b/action.yaml
@@ -1,0 +1,34 @@
+name: Pin Github Action
+description: Pin all Github Actions to a specific sha version
+runs:
+  using: docker
+  image: 'Dockerfile'
+  entrypoint: 'entrypoint.sh'
+  args: ${{ inputs.workflows_path }}
+  env: 
+    GITHUB_TOKEN: ${{ inputs.github_token }}
+    ALLOW_UNPINNED: ${{ inputs.allow_unpinned }}
+    ENFORCE: ${{ inputs.enforce }}
+    CONTINUE_ON_ERROR: ${{ inputs.continue_on_error }}
+inputs:
+  github_token:
+    description: 'Github token required to access private actions'
+    default: '${{ github.token }}'
+    required: false
+  workflows_path:
+    description: 'Path to workflows directory'
+    default: '.github/workflows'
+    required: false
+  allow_unpinned:
+    description: 'Name an action or glob of actions to leave unpinned'
+    default: ''
+    required: false
+  enforce:
+    description: 'Fail if unpinned actions are found'
+    default: 'false'
+    required: false
+  continue_on_error:
+    description: 'Continue on error. Setting this to false will stop on the first error'
+    default: 'false'
+    required: false
+  

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/ash
+# shellcheck shell=dash
+set -eu -o pipefail
+
+# Convert some provided environment variables to args
+if [ -n "${GITHUB_WORKSPACE:-}" ]; then
+  export WORKFLOWS_DIR="${GITHUB_WORKSPACE}"
+fi
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+  set -- --github-token "${GITHUB_TOKEN}" "${@}"
+fi
+if [ -n "${ALLOW_UNPINNED:-}" ]; then
+  set -- --allow-unpinned "${ALLOW_UNPINNED}" "${@}"
+fi
+if [ -n "${ENFORCE:-}" ]; then
+  set -- --enforce "${@}"
+fi
+if [ -n "${CONTINUE_ON_ERROR:-}" ]; then
+  set -- --continue-on-error "${@}"
+fi
+
+node src/bin.js "${@}" "${WORKFLOWS_PATH}"


### PR DESCRIPTION
## Changes

This wraps the tool up as a github action allowing the following:
- Dependabot can bump the action when a new release is made.
- The action itself can use a sha reference mitigating the possibility that supply chain issues could change the docker tag.
- Simple usage with useful defaults in a github action.

## Tests I've run on this code

<>